### PR TITLE
feat: CORE-7413 - allow files to be relative paths or urls

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npm test
+npm run bundle

--- a/README.md
+++ b/README.md
@@ -1,72 +1,7 @@
 # Corellium MATRIX
 
-This action runs the Corellium MATRIX solution.
+As part of our Business licenses, we offer an automated mobile application security testing tool referred to as MATRIX. The goal of MATRIX is to be a compelling and cost-effective DevSecOps solution. By harnessing the power of virtual devices, you can test your mobile applications on a wide range of devices without the need to purchase and maintain their physical counterparts.
 
-### Setup
+By building on the scalability and convenience of our cloud-based virtual devices, Corellium's MATRIX solution drastically reduces the effort, cost and time of penetration testing; enabling you to invest more into your security processes and ship more secure apps.
 
-This action requires the following repository secrets to be set up. For more information, see the GitHub's documentation for [Creating secrets for a repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-
-| Secret | Description |
-| ------ | ------ |
-| `CORELLIUM_API_TOKEN` | Corellium API token that can be created in our Web UI |
-| `CORELLIUM_PROJECT` | Corellium project ID |
-
-Create a workflow `.yml` file in your repository's `.github/workflows` directory. An example workflow can be found [here](#usage). For more information, see the GitHub's documentation for [Using workflows](https://docs.github.com/en/actions/using-workflows#creating-a-workflow-file).
-
-### Usage
-
-See [action.yml](https://github.com/corellium/matrix/blob/master/action.yml)
-
-Here's an example of how to use this action in a workflow file:
-
-```
-name: Run Corellium MATRIX solution
-
-on: [push]
-
-jobs:
-  corellium-matrix:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - run: npm ci
-      - run: npm run bundle
-
-      - name: Run MATRIX action
-        id: corellium-matrix
-        uses: ./
-        env:
-          PROJECT: ${{ secrets.CORELLIUM_PROJECT }}
-          API_TOKEN: ${{ secrets.CORELLIUM_API_TOKEN }}
-        with:
-          deviceFlavor: 'iphone14p'
-          deviceOS: '17.2'
-          server: 'https://app.corellium.com'
-          appPath: 'https://www.corellium.com/hubfs/Corellium_Cafe.ipa'
-          userActions: '/test/user-actions.json'
-          keywords: '/test/keywords.txt'
-
-      - run: echo "${{ steps.corellium-matrix.outputs.report }}"
-
-```
-
-### Inputs
-
-| Input | Description | Example | Required | Default |
-| ------ | ------ | ------ | ------ | ------ |
-| `server` | Specifies which Corellium server to use | <https://app.corellium.com> | false | <https://app.corellium.com> |
-| `deviceFlavor` | The flavor of the Instance that is being created | `iphone14p` | true | n/a |
-| `deviceOS` | The software version | `17.2` | true | n/a |
-| `appPath` | URL to download test app or local path of the app relative to the Github workspace | <https://www.corellium.com/hubfs/Corellium_Cafe.ipa> | true | n/a |
-| `userActions` | URL to download device input `.json` file or local path of the `.json` file relative to the Github workspace. Examples can be found [here](https://app.corellium.com/api/docs#post-/v1/instances/-instanceId-/input) | `/test/user-actions.json` | true | n/a |
-| `keywords` | URL to download wordlist `.txt` file or local path of the `.txt` file relative to the Github workspace | `/test/keywords.txt` | false | n/a |
-
-### Outputs
-
-| Output | Description |
-| ------ | ------ |
-| `report` | MATRIX report artifact download path relative to the Github workspace |
+[Learn more](https://support.corellium.com/features/matrix/) about MATRIX, or [get started](https://support.corellium.com/features/matrix/github-action) with our GitHub Action!

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ jobs:
           PROJECT: ${{ secrets.CORELLIUM_PROJECT }}
           API_TOKEN: ${{ secrets.CORELLIUM_API_TOKEN }}
         with:
-          flavor: 'iphone14p'
-          os: '17.2'
+          deviceFlavor: 'iphone14p'
+          deviceOS: '17.2'
           server: 'https://app.corellium.com'
-          appUrl: 'https://www.corellium.com/hubfs/Corellium_Cafe.ipa'
-          inputUrl: 'https://www.somewebsite.com/inputs.json'
+          appPath: 'https://www.corellium.com/hubfs/Corellium_Cafe.ipa'
+          userActions: '/test/user-actions.json'
+          keywords: '/test/keywords.txt'
 
       - run: echo "${{ steps.corellium-matrix.outputs.report }}"
 
@@ -58,11 +59,11 @@ jobs:
 | Input | Description | Example | Required | Default |
 | ------ | ------ | ------ | ------ | ------ |
 | `server` | Specifies which Corellium server to use | <https://app.corellium.com> | false | <https://app.corellium.com> |
-| `flavor` | The flavor of the Instance that is being created | `iphone14p` | true | n/a |
-| `os` | The software version | `17.2` | true | n/a |
-| `appUrl` | URL to download test app | <https://www.corellium.com/hubfs/Corellium_Cafe.ipa> | true | n/a |
-| `inputUrl` | URL to download device input `.json` file. Examples can be found [here](https://app.corellium.com/api/docs#post-/v1/instances/-instanceId-/input) | <https://www.somewebsite.com/inputs.json> | true | n/a |
-| `wordlistUrl` | URL to download wordlist `.txt` file | <https://www.somewebsite.com/keywords.txt> | false | n/a |
+| `deviceFlavor` | The flavor of the Instance that is being created | `iphone14p` | true | n/a |
+| `deviceOS` | The software version | `17.2` | true | n/a |
+| `appPath` | URL to download test app or local path of the app relative to the Github workspace | <https://www.corellium.com/hubfs/Corellium_Cafe.ipa> | true | n/a |
+| `userActions` | URL to download device input `.json` file or local path of the `.json` file relative to the Github workspace. Examples can be found [here](https://app.corellium.com/api/docs#post-/v1/instances/-instanceId-/input) | `/test/user-actions.json` | true | n/a |
+| `keywords` | URL to download wordlist `.txt` file or local path of the `.txt` file relative to the Github workspace | `/test/keywords.txt` | false | n/a |
 
 ### Outputs
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -328,17 +328,17 @@ describe('action', () => {
       validateExecCall(execSpy.mock.calls[6][0], 'corellium image create --project');
       validateExecCall(
         execSpy.mock.calls[7][0],
-        `corellium mast create-assessment --instance ${instanceId} --bundle ${bundleId} --wordlist ${wordlistId}`,
+        `corellium matrix create-assessment --instance ${instanceId} --bundle ${bundleId} --wordlist ${wordlistId}`,
       );
-      validateExecCall(execSpy.mock.calls[8][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[9][0], `corellium mast start-monitor --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[10][0], `corellium mast get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[8][0], `corellium matrix get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[9][0], `corellium matrix start-monitor --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[10][0], `corellium matrix get-assessment --instance ${instanceId}`);
       validateExecCall(execSpy.mock.calls[11][0], `corellium input ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[12][0], `corellium mast stop-monitor --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[13][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[14][0], `corellium mast test --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[15][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[16][0], `corellium mast download-report --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[12][0], `corellium matrix stop-monitor --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[13][0], `corellium matrix get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[14][0], `corellium matrix test --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[15][0], `corellium matrix get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[16][0], `corellium matrix download-report --instance ${instanceId}`);
       validateExecCall(execSpy.mock.calls[17][0], `corellium instance stop ${instanceId}`);
       validateExecCall(execSpy.mock.calls[18][0], `corellium instance delete ${instanceId}`);
       validateExecCall(execSpy.mock.calls[19][0], 'corellium logout');

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -5,7 +5,7 @@ import * as exec from '@actions/exec';
 import * as artifact from '@actions/artifact';
 import * as path from 'path';
 import { mocked } from 'jest-mock';
-import { readFileSync, unlinkSync } from 'fs';
+import { readFileSync, unlinkSync, promises } from 'fs';
 import * as main from '../src/main';
 
 // Unit tests for the action's main functionality, src/main.ts
@@ -16,7 +16,7 @@ jest.mock('fs', () => {
   const actual = jest.requireActual('fs');
   return {
     ...actual,
-    promises: { access: jest.fn() },
+    promises: { access: jest.fn(), stat: jest.fn() },
     readFileSync: jest.fn(),
   };
 });
@@ -28,8 +28,99 @@ let setFailedMock: jest.SpiedFunction<typeof core.setFailed>;
 let setOutputMock: jest.SpiedFunction<typeof core.setOutput>;
 
 describe('action', () => {
+  const mockUrl = 'https://www.website.com';
+
+  describe('pollAssessmentForStatus', () => {
+    beforeEach(() => {
+      jest.resetModules();
+    });
+
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw an error if the assessment goes into a failed state', async () => {
+      const execSpy = jest.spyOn(exec, 'exec');
+      execSpy
+        .mockImplementationOnce(async (_command, _args, options: any) => {
+          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
+          return 0;
+        })
+        .mockImplementationOnce(async (_command, _args, options: any) => {
+          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'failed' })));
+          return 0;
+        });
+
+      await expect(main.pollAssessmentForStatus('mockAssessmentId', 'mockInstanceId', 'complete')).rejects.toThrow(
+        'MATRIX automated test failed!',
+      );
+      expect(execSpy.mock.calls.length).toBe(2);
+    });
+
+    it('should keep polling until desired state has been reached', async () => {
+      const execSpy = jest.spyOn(exec, 'exec');
+      execSpy
+        .mockImplementationOnce(async (_command, _args, options: any) => {
+          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
+          return 0;
+        })
+        .mockImplementationOnce(async (_command, _args, options: any) => {
+          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
+          return 0;
+        })
+        .mockImplementationOnce(async (_command, _args, options: any) => {
+          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'readyForTesting' })));
+          return 0;
+        });
+
+      const resp = await main.pollAssessmentForStatus('mockAssessmentId', 'mockInstanceId', 'readyForTesting');
+      expect(resp).toEqual('readyForTesting');
+      expect(execSpy.mock.calls.length).toBe(3);
+    }, 10000);
+  });
+
+  describe('getFilePathTypes', () => {
+    beforeEach(() => {
+      jest.resetModules();
+
+      getInputMock = jest.spyOn(core, 'getInput');
+    });
+
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw an error if a file path is neither a URL or relative path', async () => {
+      getInputMock.mockImplementation(() => 'invalid');
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(false));
+
+      try {
+        await main.getFilePathTypes();
+      } catch (err: any) {
+        expect(err.message).toEqual('Provided file path is invalid: appPath');
+      }
+    });
+
+    it('should add initial forward slash if missing', async () => {
+      getInputMock.mockImplementation(() => 'test/filePath').mockImplementationOnce(() => mockUrl);
+
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(true));
+
+      const resp = await main.getFilePathTypes();
+      expect(resp).toEqual({ appPath: 'url', userActions: 'relative', keywords: 'relative' });
+    });
+
+    it('should return dict of file path types', async () => {
+      getInputMock.mockImplementation(() => '/test/filePath').mockImplementationOnce(() => mockUrl);
+
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(true));
+
+      const resp = await main.getFilePathTypes();
+      expect(resp).toEqual({ appPath: 'url', userActions: 'relative', keywords: 'relative' });
+    });
+  });
+
   describe('run', () => {
-    const mockUrl = 'https://www.website.com';
     const validateExecCall = async (actual: string, expected: string): Promise<void> => {
       expect(actual).toEqual(expect.stringContaining(expected));
     };
@@ -69,66 +160,69 @@ describe('action', () => {
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'flavor' input is missing`, async () => {
-      getInputMock.mockImplementation(name => (name === 'flavor' ? '' : 'mockVal'));
+    it(`should throw an error if 'deviceFlavor' input is missing`, async () => {
+      getInputMock.mockImplementation(name => (name === 'deviceFlavor' ? '' : 'mockVal'));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: flavor');
+      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: deviceFlavor');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'os' input is missing`, async () => {
-      getInputMock.mockImplementation(name => (name === 'os' ? '' : 'mockVal'));
+    it(`should throw an error if 'deviceOS' input is missing`, async () => {
+      getInputMock.mockImplementation(name => (name === 'deviceOS' ? '' : 'mockVal'));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: os');
+      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: deviceOS');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'appUrl' input is missing`, async () => {
-      getInputMock.mockImplementation(name => (name === 'appUrl' ? '' : 'mockVal'));
+    it(`should throw an error if 'appPath' input is missing`, async () => {
+      getInputMock.mockImplementation(name => (name === 'appPath' ? '' : 'mockVal'));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: appUrl');
+      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: appPath');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'appUrl' input is invalid`, async () => {
-      getInputMock.mockImplementation(name => (name === 'appUrl' ? 'notAUrl' : mockUrl));
+    it(`should throw an error if 'appPath' input is invalid`, async () => {
+      getInputMock.mockImplementation(name => (name === 'appPath' ? 'invalid' : mockUrl));
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(false));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Provided URL is invalid: appUrl');
+      expect(setFailedMock).toHaveBeenCalledWith('Provided file path is invalid: appPath');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'inputUrl' input is missing`, async () => {
-      getInputMock.mockImplementation(name => (name === 'inputUrl' ? '' : 'mockVal'));
+    it(`should throw an error if 'userActions' input is missing`, async () => {
+      getInputMock.mockImplementation(name => (name === 'userActions' ? '' : 'mockVal'));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: inputUrl');
+      expect(setFailedMock).toHaveBeenCalledWith('Input required and not supplied: userActions');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'inputUrl' input is invalid`, async () => {
-      getInputMock.mockImplementation(name => (name === 'inputUrl' ? 'notAUrl' : mockUrl));
+    it(`should throw an error if 'userActions' input is invalid`, async () => {
+      getInputMock.mockImplementation(name => (name === 'userActions' ? 'notValid' : mockUrl));
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(false));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Provided URL is invalid: inputUrl');
+      expect(setFailedMock).toHaveBeenCalledWith('Provided file path is invalid: userActions');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
-    it(`should throw an error if 'wordlistUrl' exists and is invalid`, async () => {
-      getInputMock.mockImplementation(name => (name === 'wordlistUrl' ? 'notAUrl' : mockUrl));
+    it(`should throw an error if 'keywords' exists and is invalid`, async () => {
+      getInputMock.mockImplementation(name => (name === 'keywords' ? 'invalid' : mockUrl));
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(false));
 
       await main.run();
       expect(runMock).toHaveReturned();
-      expect(setFailedMock).toHaveBeenCalledWith('Provided URL is invalid: wordlistUrl');
+      expect(setFailedMock).toHaveBeenCalledWith('Provided file path is invalid: keywords');
       expect(errorMock).not.toHaveBeenCalled();
     });
 
@@ -138,25 +232,40 @@ describe('action', () => {
       const instanceId = 'mockInstanceId';
       const bundleId = 'com.android.egg';
       const wordlistId = 'wordlistId';
-      getInputMock.mockImplementation(input => (input.includes('Url') ? mockUrl : 'mockVal'));
+      getInputMock.mockImplementation(input => {
+        if (input === 'appPath') {
+          return mockUrl;
+        }
+        if (input === 'userActions') {
+          return '/test/user-actions.json';
+        }
+        if (input === 'keywords') {
+          return 'test/keywords.txt';
+        }
+        return 'mockVal';
+      });
+      (promises.stat as jest.Mock).mockImplementation(async () => Promise.resolve(true));
 
       const execSpy = jest.spyOn(exec, 'exec');
       execSpy
+        // install corellium-cli
         .mockImplementationOnce(async () => Promise.resolve(0))
+        // log into cli
         .mockImplementationOnce(async () => Promise.resolve(0))
+        // create instance
         .mockImplementationOnce(async (_command, _args, options: any) => {
           options.listeners.stdout(Buffer.from(instanceId));
           return 0;
         })
+        // download app
         .mockImplementationOnce(async () => Promise.resolve(0))
+        // install app
         .mockImplementationOnce(async () => Promise.resolve(0))
         // getBundleId
         .mockImplementationOnce(async (_command, _args, options: any) => {
           options.listeners.stdout(Buffer.from(JSON.stringify([{ applicationType: 'User', bundleID: bundleId }])));
           return 0;
         })
-        .mockImplementationOnce(async () => Promise.resolve(0))
-        .mockImplementationOnce(async () => Promise.resolve(0))
         // uploadWordlistFile
         .mockImplementationOnce(async (_command, _args, options: any) => {
           options.listeners.stdout(Buffer.from(JSON.stringify([{ id: wordlistId }])));
@@ -216,76 +325,25 @@ describe('action', () => {
       validateExecCall(execSpy.mock.calls[3][0], `curl -L -o ${path.join(workspaceDir, 'appFile')} ${mockUrl}`);
       validateExecCall(execSpy.mock.calls[4][0], 'corellium apps install --project');
       validateExecCall(execSpy.mock.calls[5][0], 'corellium apps --project');
-      validateExecCall(execSpy.mock.calls[6][0], `curl -L -o ${path.join(workspaceDir, 'wordlist.txt')} ${mockUrl}`);
-      validateExecCall(execSpy.mock.calls[7][0], `curl -L -o ${path.join(workspaceDir, 'inputs.json')} ${mockUrl}`);
-      validateExecCall(execSpy.mock.calls[8][0], 'corellium image create --project');
+      validateExecCall(execSpy.mock.calls[6][0], 'corellium image create --project');
       validateExecCall(
-        execSpy.mock.calls[9][0],
+        execSpy.mock.calls[7][0],
         `corellium mast create-assessment --instance ${instanceId} --bundle ${bundleId} --wordlist ${wordlistId}`,
       );
+      validateExecCall(execSpy.mock.calls[8][0], `corellium mast get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[9][0], `corellium mast start-monitor --instance ${instanceId}`);
       validateExecCall(execSpy.mock.calls[10][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[11][0], `corellium mast start-monitor --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[12][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[13][0], `corellium input ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[14][0], `corellium mast stop-monitor --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[11][0], `corellium input ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[12][0], `corellium mast stop-monitor --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[13][0], `corellium mast get-assessment --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[14][0], `corellium mast test --instance ${instanceId}`);
       validateExecCall(execSpy.mock.calls[15][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[16][0], `corellium mast test --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[17][0], `corellium mast get-assessment --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[18][0], `corellium mast download-report --instance ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[19][0], `corellium instance stop ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[20][0], `corellium instance delete ${instanceId}`);
-      validateExecCall(execSpy.mock.calls[21][0], 'corellium logout');
+      validateExecCall(execSpy.mock.calls[16][0], `corellium mast download-report --instance ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[17][0], `corellium instance stop ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[18][0], `corellium instance delete ${instanceId}`);
+      validateExecCall(execSpy.mock.calls[19][0], 'corellium logout');
 
       unlinkSync(path.join(__dirname, './report.html'));
     }, 15000);
-  });
-
-  describe('pollAssessmentForStatus', () => {
-    beforeEach(() => {
-      jest.resetModules();
-    });
-
-    afterEach(async () => {
-      jest.clearAllMocks();
-    });
-
-    it('should throw an error if the assessment goes into a failed state', async () => {
-      const execSpy = jest.spyOn(exec, 'exec');
-      execSpy
-        .mockImplementationOnce(async (_command, _args, options: any) => {
-          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
-          return 0;
-        })
-        .mockImplementationOnce(async (_command, _args, options: any) => {
-          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'failed' })));
-          return 0;
-        });
-
-      await expect(main.pollAssessmentForStatus('mockAssessmentId', 'mockInstanceId', 'complete')).rejects.toThrow(
-        'MATRIX automated test failed!',
-      );
-      expect(execSpy.mock.calls.length).toBe(2);
-    });
-
-    it('should keep polling until desired state has been reached', async () => {
-      const execSpy = jest.spyOn(exec, 'exec');
-      execSpy
-        .mockImplementationOnce(async (_command, _args, options: any) => {
-          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
-          return 0;
-        })
-        .mockImplementationOnce(async (_command, _args, options: any) => {
-          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'testing' })));
-          return 0;
-        })
-        .mockImplementationOnce(async (_command, _args, options: any) => {
-          options.listeners.stdout(Buffer.from(JSON.stringify({ status: 'readyForTesting' })));
-          return 0;
-        });
-
-      const resp = await main.pollAssessmentForStatus('mockAssessmentId', 'mockInstanceId', 'readyForTesting');
-      expect(resp).toEqual('readyForTesting');
-      expect(execSpy.mock.calls.length).toBe(3);
-    }, 10000);
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -4,26 +4,26 @@ author: 'Corellium, Inc. <support@corellium.com>'
 branding:
   color: 'gray-dark'
   icon: 'smartphone'
-  
+
 inputs:
   server:
     description: 'Specifies which Corellium server to use'
     required: false
     default: 'https://app.corellium.com'
-  flavor:
+  deviceFlavor:
     description: 'The flavor of the Instance that is being created'
     required: true
-  os:
+  deviceOS:
     description: 'The software version'
     required: true
-  appUrl:
-    description: 'URL to download test app'
+  appPath:
+    description: 'URL to download test app or local path of the app relative to the Github workspace'
     required: true
-  inputUrl:
-    description: 'URL to download device input JSON file'
+  userActions:
+    description: 'URL to download device input JSON file or local path of the JSON file relative to the Github workspace'
     required: true
-  wordlistUrl:
-    description: 'URL to download wordlist txt file'
+  keywords:
+    description: 'URL to download wordlist txt file or local path of the txt file relative to the Github workspace'
     required: false
 
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -97895,7 +97895,7 @@ async function run() {
 exports.run = run;
 async function installCorelliumCli() {
     core.info('Installing Corellium-CLI...');
-    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli@1.2.4');
+    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli');
     await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 async function setupDevice(pathTypes) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -97895,7 +97895,7 @@ async function run() {
 exports.run = run;
 async function installCorelliumCli() {
     core.info('Installing Corellium-CLI...');
-    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli');
+    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli@1.2.7');
     await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 async function setupDevice(pathTypes) {
@@ -97921,7 +97921,7 @@ async function runMatrix(instanceId, pathTypes) {
     core.info('Creating assessment...');
     let assessmentId;
     try {
-        let createAssessment = `corellium mast create-assessment --instance ${instanceId} --bundle ${bundleId}`;
+        let createAssessment = `corellium matrix create-assessment --instance ${instanceId} --bundle ${bundleId}`;
         if (wordlistId) {
             createAssessment += ` --wordlist ${wordlistId}`;
         }
@@ -97934,20 +97934,20 @@ async function runMatrix(instanceId, pathTypes) {
     }
     await pollAssessmentForStatus(assessmentId, instanceId, 'new');
     core.info('Starting monitor...');
-    await execCmd(`corellium mast start-monitor --instance ${instanceId} --assessment ${assessmentId}`);
+    await execCmd(`corellium matrix start-monitor --instance ${instanceId} --assessment ${assessmentId}`);
     await pollAssessmentForStatus(assessmentId, instanceId, 'monitoring');
     core.info('Executing inputs on device...');
     await execCmd(`corellium input ${instanceId} ${inputsFilePath}`);
     core.info(`Waiting ${inputsTimeout}ms for inputs to execute...`);
     await wait(inputsTimeout);
     core.info('Stopping monitor...');
-    await execCmd(`corellium mast stop-monitor --instance ${instanceId} --assessment ${assessmentId}`);
+    await execCmd(`corellium matrix stop-monitor --instance ${instanceId} --assessment ${assessmentId}`);
     await pollAssessmentForStatus(assessmentId, instanceId, 'readyForTesting');
     core.info('Executing tests...');
-    await execCmd(`corellium mast test --instance ${instanceId} --assessment ${assessmentId}`);
+    await execCmd(`corellium matrix test --instance ${instanceId} --assessment ${assessmentId}`);
     await pollAssessmentForStatus(assessmentId, instanceId, 'complete');
     core.info('Downloading assessment...');
-    return await execCmd(`corellium mast download-report --instance ${instanceId} --assessment ${assessmentId}`);
+    return await execCmd(`corellium matrix download-report --instance ${instanceId} --assessment ${assessmentId}`);
 }
 async function cleanup(instanceId) {
     core.info('Cleaning up...');
@@ -97994,7 +97994,7 @@ async function downloadInputFile(pathType) {
 }
 async function pollAssessmentForStatus(assessmentId, instanceId, expectedStatus) {
     const getAssessmentStatus = async () => {
-        const resp = await execCmd(`corellium mast get-assessment --instance ${instanceId} --assessment ${assessmentId}`);
+        const resp = await execCmd(`corellium matrix get-assessment --instance ${instanceId} --assessment ${assessmentId}`);
         return tryJsonParse(resp)?.status;
     };
     let actualStatus = await getAssessmentStatus();

--- a/dist/index.js
+++ b/dist/index.js
@@ -97860,22 +97860,28 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.pollAssessmentForStatus = exports.run = void 0;
+exports.getFilePathTypes = exports.pollAssessmentForStatus = exports.run = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const exec_1 = __nccwpck_require__(1514);
 const artifact_1 = __nccwpck_require__(9450);
 const path = __importStar(__nccwpck_require__(1017));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
+var PathType;
+(function (PathType) {
+    PathType["URL"] = "url";
+    PathType["RELATIVE"] = "relative";
+})(PathType || (PathType = {}));
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 async function run() {
     try {
-        validateInputsAndVars();
+        validateInputsAndEnv();
+        const pathTypes = await getFilePathTypes();
         await installCorelliumCli();
-        const instanceId = await setupDevice();
-        const report = await runMast(instanceId);
+        const instanceId = await setupDevice(pathTypes);
+        const report = await runMatrix(instanceId, pathTypes);
         await cleanup(instanceId);
         await storeReportInArtifacts(report);
     }
@@ -97892,26 +97898,26 @@ async function installCorelliumCli() {
     await (0, exec_1.exec)('npm install -g @corellium/corellium-cli');
     await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
-async function setupDevice() {
+async function setupDevice(pathTypes) {
     const projectId = process.env.PROJECT;
     core.info('Creating device...');
-    const resp = await execCmd(`corellium instance create ${core.getInput('flavor')} ${core.getInput('os')} ${projectId} --wait`);
+    const resp = await execCmd(`corellium instance create ${core.getInput('deviceFlavor')} ${core.getInput('deviceOS')} ${projectId} --wait`);
     const instanceId = resp?.toString().trim();
     core.info('Downloading app...');
-    const appPath = await downloadFile('appFile', core.getInput('appUrl'));
+    const appPath = await downloadFile('appFile', core.getInput('appPath'), pathTypes.appPath);
     core.info(`Installing app on ${instanceId}...`);
     await execCmd(`corellium apps install --project ${projectId} --instance ${instanceId} --app ${appPath}`);
     return instanceId;
 }
-async function runMast(instanceId) {
+async function runMatrix(instanceId, pathTypes) {
     const [bundleId, wordlistId, inputInfo] = await Promise.all([
         getBundleId(instanceId),
-        uploadWordlistFile(instanceId),
-        downloadInputFile(),
+        uploadWordlistFile(instanceId, pathTypes.keywords),
+        downloadInputFile(pathTypes.userActions),
     ]);
     const inputsFilePath = inputInfo.inputsFilePath;
     const inputsTimeout = inputInfo.inputsTimeout;
-    core.info('Running MAST...');
+    core.info('Running MATRIX...');
     core.info('Creating assessment...');
     let assessmentId;
     try {
@@ -97924,7 +97930,7 @@ async function runMast(instanceId) {
         core.info(`Created assessment ${assessmentId}...`);
     }
     catch (err) {
-        throw new Error(`Error creating MAST assessment! err=${err}`);
+        throw new Error(`Error creating MATRIX assessment! err=${err}`);
     }
     await pollAssessmentForStatus(assessmentId, instanceId, 'new');
     core.info('Starting monitor...');
@@ -97958,21 +97964,21 @@ async function getBundleId(instanceId) {
     }
     return bundleId;
 }
-async function uploadWordlistFile(instanceId) {
-    const wordlistUrl = core.getInput('wordlistUrl');
-    if (!wordlistUrl) {
+async function uploadWordlistFile(instanceId, pathType) {
+    const keywords = core.getInput('keywords');
+    if (!keywords) {
         return;
     }
     core.info('Uploading wordlist...');
-    const wordlistPath = await downloadFile('wordlist.txt', wordlistUrl);
+    const wordlistPath = await downloadFile('wordlist.txt', keywords, pathType);
     const resp = await execCmd(`corellium image create --project ${process.env.PROJECT} --instance ${instanceId} --format json wordlist.txt mast-wordlist plain ${wordlistPath}`);
     const uploadedWordlistResp = tryJsonParse(resp);
     const wordlistId = uploadedWordlistResp?.[0].id;
     core.info(`Uploaded wordlist: ${wordlistId}`);
     return wordlistId;
 }
-async function downloadInputFile() {
-    const inputsFilePath = await downloadFile('inputs.json', core.getInput('inputUrl'));
+async function downloadInputFile(pathType) {
+    const inputsFilePath = await downloadFile('inputs.json', core.getInput('userActions'), pathType);
     // estimating time it takes to execute device inputs - has 10s buffer
     const inputsJson = JSON.parse(fs_1.default.readFileSync(inputsFilePath, 'utf-8'));
     const inputsTimeout = inputsJson.reduce((acc, curr) => {
@@ -97996,7 +98002,7 @@ async function pollAssessmentForStatus(assessmentId, instanceId, expectedStatus)
         await wait();
         actualStatus = await getAssessmentStatus();
         if (actualStatus === 'failed') {
-            throw new Error('MAST automated test failed!');
+            throw new Error('MATRIX automated test failed!');
         }
     }
     return actualStatus;
@@ -98007,14 +98013,14 @@ async function storeReportInArtifacts(report) {
     const reportPath = path.join(workspaceDir, 'report.html');
     fs_1.default.writeFileSync(reportPath, report);
     const artifact = new artifact_1.DefaultArtifactClient();
-    const { id } = await artifact.uploadArtifact('mast-report', ['./report.html'], workspaceDir);
+    const { id } = await artifact.uploadArtifact('matrix-report', ['./report.html'], workspaceDir);
     if (!id) {
-        throw new Error('Failed to upload MAST report artifact!');
+        throw new Error('Failed to upload MATRIX report artifact!');
     }
     const { downloadPath } = await artifact.downloadArtifact(id);
     core.setOutput('report', downloadPath);
 }
-function validateInputsAndVars() {
+function validateInputsAndEnv() {
     if (!process.env.API_TOKEN) {
         throw new Error('Environment secret missing: API_TOKEN');
     }
@@ -98022,31 +98028,25 @@ function validateInputsAndVars() {
         throw new Error('Environment secret missing: PROJECT');
     }
     // inputs from action file are not validated https://github.com/actions/runner/issues/1070
-    const requiredInputs = ['flavor', 'os', 'appUrl', 'inputUrl'];
+    const requiredInputs = ['deviceFlavor', 'deviceOS', 'appPath', 'userActions'];
     requiredInputs.forEach((input) => {
         const inputResp = core.getInput(input);
         if (!inputResp || typeof inputResp !== 'string' || inputResp === '') {
             throw new Error(`Input required and not supplied: ${input}`);
         }
     });
-    const urlInputs = ['appUrl', 'inputUrl', 'wordlistUrl'];
-    urlInputs.forEach((urlInput) => {
-        const url = core.getInput(urlInput);
-        if (url) {
-            try {
-                new URL(url);
-            }
-            catch (_) {
-                throw new Error(`Provided URL is invalid: ${urlInput}`);
-            }
-        }
-    });
 }
-async function downloadFile(fileName, url) {
+async function downloadFile(fileNameToSave, pathValue, pathType) {
     const workspaceDir = process.env.GITHUB_WORKSPACE;
-    const downloadPath = path.join(workspaceDir, fileName);
-    await (0, exec_1.exec)(`curl -L -o ${downloadPath} ${url}`, [], { silent: true });
-    return downloadPath;
+    const downloadPath = path.join(workspaceDir, fileNameToSave);
+    // download file from URL, otherwise already on github workspace
+    if (pathType === PathType.URL) {
+        await (0, exec_1.exec)(`curl -L -o ${downloadPath} ${pathValue}`, [], { silent: true });
+        return downloadPath;
+    }
+    else {
+        return `${workspaceDir}${pathValue.startsWith('/') ? pathValue : `/${pathValue}`}`;
+    }
 }
 async function wait(ms = 3000) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -98071,6 +98071,33 @@ async function execCmd(cmd) {
     }
     return resp;
 }
+async function getFilePathTypes() {
+    // these can be either URLs or file relative to the github workspace
+    const pathInputs = ['appPath', 'userActions', 'keywords'];
+    const workspaceDir = process.env.GITHUB_WORKSPACE;
+    const pathInputsWithTypes = {};
+    for (const pathInput of pathInputs) {
+        const filePath = core.getInput(pathInput);
+        if (filePath) {
+            try {
+                new URL(filePath);
+                pathInputsWithTypes[pathInput] = PathType.URL;
+                continue;
+            }
+            catch (_) {
+                if (!!(await fs_1.default.promises
+                    .stat(`${workspaceDir}${filePath.startsWith('/') ? filePath : `/${filePath}`}`)
+                    .catch(() => false))) {
+                    pathInputsWithTypes[pathInput] = PathType.RELATIVE;
+                    continue;
+                }
+                throw new Error(`Provided file path is invalid: ${pathInput}`);
+            }
+        }
+    }
+    return pathInputsWithTypes;
+}
+exports.getFilePathTypes = getFilePathTypes;
 function tryJsonParse(jsonStr) {
     let obj = undefined;
     if (jsonStr && typeof jsonStr === 'string' && jsonStr !== '') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -97895,7 +97895,7 @@ async function run() {
 exports.run = run;
 async function installCorelliumCli() {
     core.info('Installing Corellium-CLI...');
-    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli');
+    await (0, exec_1.exec)('npm install -g @corellium/corellium-cli@1.2.4');
     await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 async function setupDevice(pathTypes) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run(): Promise<void> {
 
 async function installCorelliumCli(): Promise<void> {
   core.info('Installing Corellium-CLI...');
-  await exec('npm install -g @corellium/corellium-cli@1.2.4');
+  await exec('npm install -g @corellium/corellium-cli');
   await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run(): Promise<void> {
 
 async function installCorelliumCli(): Promise<void> {
   core.info('Installing Corellium-CLI...');
-  await exec('npm install -g @corellium/corellium-cli');
+  await exec('npm install -g @corellium/corellium-cli@1.2.7');
   await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 
@@ -69,7 +69,7 @@ async function runMatrix(instanceId: string, pathTypes: FilePathTypes): Promise<
   core.info('Creating assessment...');
   let assessmentId: string | undefined;
   try {
-    let createAssessment = `corellium mast create-assessment --instance ${instanceId} --bundle ${bundleId}`;
+    let createAssessment = `corellium matrix create-assessment --instance ${instanceId} --bundle ${bundleId}`;
     if (wordlistId) {
       createAssessment += ` --wordlist ${wordlistId}`;
     }
@@ -82,7 +82,7 @@ async function runMatrix(instanceId: string, pathTypes: FilePathTypes): Promise<
 
   await pollAssessmentForStatus(assessmentId, instanceId, 'new');
   core.info('Starting monitor...');
-  await execCmd(`corellium mast start-monitor --instance ${instanceId} --assessment ${assessmentId}`);
+  await execCmd(`corellium matrix start-monitor --instance ${instanceId} --assessment ${assessmentId}`);
 
   await pollAssessmentForStatus(assessmentId, instanceId, 'monitoring');
   core.info('Executing inputs on device...');
@@ -91,15 +91,15 @@ async function runMatrix(instanceId: string, pathTypes: FilePathTypes): Promise<
   await wait(inputsTimeout);
 
   core.info('Stopping monitor...');
-  await execCmd(`corellium mast stop-monitor --instance ${instanceId} --assessment ${assessmentId}`);
+  await execCmd(`corellium matrix stop-monitor --instance ${instanceId} --assessment ${assessmentId}`);
 
   await pollAssessmentForStatus(assessmentId, instanceId, 'readyForTesting');
   core.info('Executing tests...');
-  await execCmd(`corellium mast test --instance ${instanceId} --assessment ${assessmentId}`);
+  await execCmd(`corellium matrix test --instance ${instanceId} --assessment ${assessmentId}`);
 
   await pollAssessmentForStatus(assessmentId, instanceId, 'complete');
   core.info('Downloading assessment...');
-  return await execCmd(`corellium mast download-report --instance ${instanceId} --assessment ${assessmentId}`);
+  return await execCmd(`corellium matrix download-report --instance ${instanceId} --assessment ${assessmentId}`);
 }
 
 async function cleanup(instanceId: string): Promise<void> {
@@ -160,7 +160,7 @@ export async function pollAssessmentForStatus(
   expectedStatus: string,
 ): Promise<string> {
   const getAssessmentStatus = async (): Promise<string> => {
-    const resp = await execCmd(`corellium mast get-assessment --instance ${instanceId} --assessment ${assessmentId}`);
+    const resp = await execCmd(`corellium matrix get-assessment --instance ${instanceId} --assessment ${assessmentId}`);
     return (tryJsonParse(resp) as { status: string })?.status;
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,16 +4,23 @@ import { DefaultArtifactClient } from '@actions/artifact';
 import * as path from 'path';
 import fs from 'fs';
 
+enum PathType {
+  URL = 'url',
+  RELATIVE = 'relative',
+}
+type FilePathTypes = Record<string, PathType>;
+
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 export async function run(): Promise<void> {
   try {
-    validateInputsAndVars();
+    validateInputsAndEnv();
+    const pathTypes = await getFilePathTypes();
     await installCorelliumCli();
-    const instanceId = await setupDevice();
-    const report = await runMatrix(instanceId);
+    const instanceId = await setupDevice(pathTypes);
+    const report = await runMatrix(instanceId, pathTypes);
     await cleanup(instanceId);
     await storeReportInArtifacts(report);
   } catch (error) {
@@ -30,17 +37,17 @@ async function installCorelliumCli(): Promise<void> {
   await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 
-async function setupDevice(): Promise<string> {
+async function setupDevice(pathTypes: FilePathTypes): Promise<string> {
   const projectId = process.env.PROJECT;
 
   core.info('Creating device...');
   const resp = await execCmd(
-    `corellium instance create ${core.getInput('flavor')} ${core.getInput('os')} ${projectId} --wait`,
+    `corellium instance create ${core.getInput('deviceFlavor')} ${core.getInput('deviceOS')} ${projectId} --wait`,
   );
   const instanceId = resp?.toString().trim();
 
   core.info('Downloading app...');
-  const appPath = await downloadFile('appFile', core.getInput('appUrl'));
+  const appPath = await downloadFile('appFile', core.getInput('appPath'), pathTypes.appPath);
 
   core.info(`Installing app on ${instanceId}...`);
   await execCmd(`corellium apps install --project ${projectId} --instance ${instanceId} --app ${appPath}`);
@@ -48,13 +55,12 @@ async function setupDevice(): Promise<string> {
   return instanceId;
 }
 
-async function runMatrix(instanceId: string): Promise<string> {
+async function runMatrix(instanceId: string, pathTypes: FilePathTypes): Promise<string> {
   const [bundleId, wordlistId, inputInfo] = await Promise.all([
     getBundleId(instanceId),
-    uploadWordlistFile(instanceId),
-    downloadInputFile(),
+    uploadWordlistFile(instanceId, pathTypes.keywords),
+    downloadInputFile(pathTypes.userActions),
   ]);
-
   const inputsFilePath = inputInfo.inputsFilePath;
   const inputsTimeout = inputInfo.inputsTimeout;
 
@@ -113,14 +119,14 @@ async function getBundleId(instanceId: string): Promise<string> {
   return bundleId;
 }
 
-async function uploadWordlistFile(instanceId: string): Promise<string | undefined> {
-  const wordlistUrl = core.getInput('wordlistUrl');
-  if (!wordlistUrl) {
+async function uploadWordlistFile(instanceId: string, pathType: PathType): Promise<string | undefined> {
+  const keywords = core.getInput('keywords');
+  if (!keywords) {
     return;
   }
 
   core.info('Uploading wordlist...');
-  const wordlistPath = await downloadFile('wordlist.txt', wordlistUrl);
+  const wordlistPath = await downloadFile('wordlist.txt', keywords, pathType);
   const resp = await execCmd(
     `corellium image create --project ${process.env.PROJECT} --instance ${instanceId} --format json wordlist.txt mast-wordlist plain ${wordlistPath}`,
   );
@@ -130,8 +136,8 @@ async function uploadWordlistFile(instanceId: string): Promise<string | undefine
   return wordlistId;
 }
 
-async function downloadInputFile(): Promise<{ inputsFilePath: string; inputsTimeout: number }> {
-  const inputsFilePath = await downloadFile('inputs.json', core.getInput('inputUrl'));
+async function downloadInputFile(pathType: PathType): Promise<{ inputsFilePath: string; inputsTimeout: number }> {
+  const inputsFilePath = await downloadFile('inputs.json', core.getInput('userActions'), pathType);
 
   // estimating time it takes to execute device inputs - has 10s buffer
   const inputsJson = JSON.parse(fs.readFileSync(inputsFilePath, 'utf-8'));
@@ -187,7 +193,7 @@ async function storeReportInArtifacts(report: string): Promise<void> {
   core.setOutput('report', downloadPath);
 }
 
-function validateInputsAndVars(): void {
+function validateInputsAndEnv(): void {
   if (!process.env.API_TOKEN) {
     throw new Error('Environment secret missing: API_TOKEN');
   }
@@ -196,32 +202,26 @@ function validateInputsAndVars(): void {
   }
 
   // inputs from action file are not validated https://github.com/actions/runner/issues/1070
-  const requiredInputs = ['flavor', 'os', 'appUrl', 'inputUrl'];
+  const requiredInputs = ['deviceFlavor', 'deviceOS', 'appPath', 'userActions'];
   requiredInputs.forEach((input: string) => {
     const inputResp = core.getInput(input);
     if (!inputResp || typeof inputResp !== 'string' || inputResp === '') {
       throw new Error(`Input required and not supplied: ${input}`);
     }
   });
-
-  const urlInputs = ['appUrl', 'inputUrl', 'wordlistUrl'];
-  urlInputs.forEach((urlInput: string) => {
-    const url = core.getInput(urlInput);
-    if (url) {
-      try {
-        new URL(url);
-      } catch (_) {
-        throw new Error(`Provided URL is invalid: ${urlInput}`);
-      }
-    }
-  });
 }
 
-async function downloadFile(fileName: string, url: string): Promise<string> {
+async function downloadFile(fileNameToSave: string, pathValue: string, pathType: PathType): Promise<string> {
   const workspaceDir = process.env.GITHUB_WORKSPACE as string;
-  const downloadPath = path.join(workspaceDir, fileName);
-  await exec(`curl -L -o ${downloadPath} ${url}`, [], { silent: true });
-  return downloadPath;
+  const downloadPath = path.join(workspaceDir, fileNameToSave);
+
+  // download file from URL, otherwise already on github workspace
+  if (pathType === PathType.URL) {
+    await exec(`curl -L -o ${downloadPath} ${pathValue}`, [], { silent: true });
+    return downloadPath;
+  } else {
+    return `${workspaceDir}${pathValue.startsWith('/') ? pathValue : `/${pathValue}`}`;
+  }
 }
 
 async function wait(ms = 3000): Promise<void> {
@@ -248,6 +248,37 @@ async function execCmd(cmd: string): Promise<string> {
     throw new Error(`Error occurred executing ${cmd}! err=${err}`);
   }
   return resp;
+}
+
+export async function getFilePathTypes(): Promise<FilePathTypes> {
+  // these can be either URLs or file relative to the github workspace
+  const pathInputs = ['appPath', 'userActions', 'keywords'];
+
+  const workspaceDir = process.env.GITHUB_WORKSPACE as string;
+
+  const pathInputsWithTypes: FilePathTypes = {};
+  for (const pathInput of pathInputs) {
+    const filePath = core.getInput(pathInput);
+    if (filePath) {
+      try {
+        new URL(filePath);
+        pathInputsWithTypes[pathInput] = PathType.URL;
+        continue;
+      } catch (_) {
+        if (
+          !!(await fs.promises
+            .stat(`${workspaceDir}${filePath.startsWith('/') ? filePath : `/${filePath}`}`)
+            .catch(() => false))
+        ) {
+          pathInputsWithTypes[pathInput] = PathType.RELATIVE;
+          continue;
+        }
+
+        throw new Error(`Provided file path is invalid: ${pathInput}`);
+      }
+    }
+  }
+  return pathInputsWithTypes;
 }
 
 function tryJsonParse(jsonStr: string): Record<string, unknown> | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run(): Promise<void> {
 
 async function installCorelliumCli(): Promise<void> {
   core.info('Installing Corellium-CLI...');
-  await exec('npm install -g @corellium/corellium-cli');
+  await exec('npm install -g @corellium/corellium-cli@1.2.4');
   await execCmd(`corellium login --endpoint ${core.getInput('server')} --apitoken ${process.env.API_TOKEN}`);
 }
 


### PR DESCRIPTION
Renames the following inputs:
`flavor` -> `deviceFlavor`
`os` ->  `deviceOS`
`appUrl` -> `appPath`
`inputUrl` -> `userActions`
`wordlistUrl` -> `keywords`

Allows `appPath`, `userActions`, and `keywords` to be either URLs to download the files OR local paths to the file relative to the Github workspace.